### PR TITLE
Update versions.vtl to Apache Shiro 1.4

### DIFF
--- a/templates/versions.vtl
+++ b/templates/versions.vtl
@@ -1,7 +1,7 @@
-#set( $latestRelease = "1.3.2" )
-#set( $versionInfo = {"1.3.2": { "releaseDate": "2016-09-12" } } )
+#set( $latestRelease = "1.4.0" )
+#set( $versionInfo = {"1.4.0": { "releaseDate": "2017-05-05" } } )
 
-#set( $earlyRelease = "1.4.0-RC2" )
+#set( $earlyRelease = "1.4.1-SNAPSHOT" )
 
 #set( $shiroCore = {"g":"org.apache.shiro", "a": "shiro-core", "type": "jar",
                     "description": 'Required in all environments. <a class="external-link" href="http://slf4j.org/">Slf4j</a>''s


### PR DESCRIPTION
I was actually looking for issues, but shiro-site has no issues only pull requests.

Anyways the site is missing Apache Shiro 1.4! Great new version, out since May, but the homepage does not reflect this. Sad. 

Tried to fix this but I can't get SCMS to work properly.

* Cloned the shiro-site project
* Created an empty shiro-site-target folder on my Desktop
* Downloaded SCMS
* cd shiro-site
* scms ~/Desktop/shiro-site-target

SCMS runs through without any errors. If I proceed to publish the contents of shio-site-target on a web server I can get some sites to run, others don't. index.html runs. If I click on Docs in the main nav I get an 404 because documentation.html is missing.

Verified that. It creates a documentation.md.html file but not a documentation.html.

