### PR TITLE
fix typo spells weild not wield

### DIFF
--- a/10-minute-tutorial.md.vtl
+++ b/10-minute-tutorial.md.vtl
@@ -158,7 +158,7 @@ if ( currentUser.hasRole( "schwartz" ) ) {
 We can also see if they have a permission to act on a certain type of entity:
 
 ``` java
-if ( currentUser.isPermitted( "lightsaber:weild" ) ) {
+if ( currentUser.isPermitted( "lightsaber:wield" ) ) {
     log.info("You may use a lightsaber ring.  Use it wisely.");
 } else {
     log.info("Sorry, lightsaber rings are for schwartz masters only.");

--- a/subject.md.vtl
+++ b/subject.md.vtl
@@ -104,7 +104,7 @@ if ( currentUser.hasRole( "schwartz" ) ) {
 We can also see if they have a [permission](permissions.html "Permissions") to act on a certain type of entity:
 
 ``` java
-if ( currentUser.isPermitted( "lightsaber:weild" ) ) {
+if ( currentUser.isPermitted( "lightsaber:wield" ) ) {
     log.info("You may use a lightsaber ring.  Use it wisely.");
 } else {
     log.info("Sorry, lightsaber rings are for schwartz masters only.");


### PR DESCRIPTION
This changes two misspellings of wield as weild. I allege this is
a misspelling because it does not match the corresponding code [0]

[0] https://github.com/apache/shiro/blob/master/samples/quickstart/src/main/java/Quickstart.java#L106