### PR TITLE
Remove nabble mailing list archive links

### DIFF
--- a/forums.md
+++ b/forums.md
@@ -1,10 +1,12 @@
 <a name="Forums-ApacheShiroCommunityForums"></a>
 #Apache Shiro Community Forums
 
-For users that prefer to use forums over mailing lists, we use the [Nabble](http://www.nabble.com) forum/email/archive service. Nabble ensures that its forums remain synchronized with the mailing lists, so feel free to use whichever mechanism you like.
+For users that prefer to use browse the mailing lists with a browser can use [ASF Lists](https://lists.apache.org/) (Pony Mail). 
 
-*   [Shiro User Forum](http://shiro-user.582556.n2.nabble.com/)
-*   [Shiro Developer Forum](http://shiro-developer.582600.n2.nabble.com/)
+*   [Shiro User Forum](https://lists.apache.org/list.html?user@shiro.apache.org)
+*   [Shiro Developer Forum](https://lists.apache.org/list.html?dev@shiro.apache.org)
+
+> **NOTE:** Previously, `nabble.com` was used as an alternative to the mailing list, this service is not longer hosting the mailing list archive.
 
 <a name="Forums-MailingLists"></a>
 ##Mailing Lists

--- a/mailing-lists.md.vtl
+++ b/mailing-lists.md.vtl
@@ -1,17 +1,17 @@
 #mdStyle()
 
 <a name="MailingLists-ApacheShiroMailingLists"></a>
-#Apache Shiro Mailing Lists
+# Apache Shiro Mailing Lists
 
-| List Name            | List Address                                                | Subscribe                                              | Unsubscribe                                                | ASF Archive                                                            | Nabble (Online Forums)                                                   |
-|----------------------|-------------------------------------------------------------|--------------------------------------------------------|------------------------------------------------------------|------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| Shiro User List      | [user@shiro.apache.org](mailto:user@shiro.apache.org)       | [Subscribe](mailto:user-subscribe@shiro.apache.org)    | [Unsubscribe](mailto:user-unsubscribe@shiro.apache.org)    | [ASF Archive](http://mail-archives.apache.org/mod_mbox/shiro-user/)    | [Nabble Forum and Archive](http://shiro-user.582556.n2.nabble.com/)      |
-| Shiro Developer List | [dev@shiro.apache.org](mailto:dev@shiro.apache.org)         | [Subscribe](mailto:dev-subscribe@shiro.apache.org)     | [Unsubscribe](mailto:dev-unsubscribe@shiro.apache.org)     | [ASF Archive](http://mail-archives.apache.org/mod_mbox/shiro-dev/)     | [Nabble Forum and Archive](http://shiro-developer.582600.n2.nabble.com/) |
-| Shiro Issues/JIRA List | [issues@shiro.apache.org](mailto:issues@shiro.apache.org) | [Subscribe](mailto:issues-subscribe@shiro.apache.org)  | [Unsubscribe](mailto:issues-unsubscribe@shiro.apache.org)  | [ASF Archive](http://mail-archives.apache.org/mod_mbox/shiro-issues/)  |                                                                          |
-| Shiro SCM List       | [commits@shiro.apache.org](mailto:commits@shiro.apache.org) | [Subscribe](mailto:commits-subscribe@shiro.apache.org) | [Unsubscribe](mailto:commits-unsubscribe@shiro.apache.org) | [ASF Archive](http://mail-archives.apache.org/mod_mbox/shiro-commits/) |                                                                          |
+| List Name            | List Address                                                | Subscribe                                              | Unsubscribe                                                | ASF (Online Forums)                                                                  |
+|----------------------|-------------------------------------------------------------|--------------------------------------------------------|------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| Shiro User List      | [user@shiro.apache.org](mailto:user@shiro.apache.org)       | [Subscribe](mailto:user-subscribe@shiro.apache.org)    | [Unsubscribe](mailto:user-unsubscribe@shiro.apache.org)    | [ASF Forum and Archive](https://lists.apache.org/list.html?user@shiro.apache.org)    |
+| Shiro Developer List | [dev@shiro.apache.org](mailto:dev@shiro.apache.org)         | [Subscribe](mailto:dev-subscribe@shiro.apache.org)     | [Unsubscribe](mailto:dev-unsubscribe@shiro.apache.org)     | [ASF Forum and Archive](https://lists.apache.org/list.html?dev@shiro.apache.org)     |
+| Shiro Issues/JIRA List | [issues@shiro.apache.org](mailto:issues@shiro.apache.org) | [Subscribe](mailto:issues-subscribe@shiro.apache.org)  | [Unsubscribe](mailto:issues-unsubscribe@shiro.apache.org)  | [ASF Forum and Archive](https://lists.apache.org/list.html?issues@shiro.apache.org)  |
+| Shiro SCM List       | [commits@shiro.apache.org](mailto:commits@shiro.apache.org) | [Subscribe](mailto:commits-subscribe@shiro.apache.org) | [Unsubscribe](mailto:commits-unsubscribe@shiro.apache.org) | [ASF Forum and Archive](https://lists.apache.org/list.html?commits@shiro.apache.org) |
 
 <a name="MailingLists-DiscussionForums"></a>
-###Discussion Forums
+### Discussion Forums
 
 If you prefer you could use our discussion [Forums](forums.html "Forums") which are sync'd with the above mailing lists.
 <input type="hidden" id="ghEditPage" value="mailing-lists.md"></input>


### PR DESCRIPTION
Replace with the ASF Pony Mail links

Nabble is downsizing: https://support.nabble.com/Downsizing-Nabble-td7609715.html