### PR TITLE
[SHIRO-856] add time tag and proper author information.

### DIFF
--- a/src/site/templates/post.ftl
+++ b/src/site/templates/post.ftl
@@ -6,7 +6,36 @@
 	</div>
 	<#else></#if>
 
-	<p><em>${content.date?string("dd MMMM yyyy")}</em></p>
+	<#setting locale="en_GB" />
+  <#if (content.author??)>
+		<#assign authors=data.get('authors.yaml').authors />
+		<#if (authors[content.author])?? && (authors[content.author].twitter)??>
+			<#assign theauthor="by <a rel=\"author\" href=\"https://twitter.com/${authors[content.author].twitter}\">${content.author}</a>&nbsp;" />
+		<#else>
+			<#assign theauthor="by ${content.author}&nbsp;" />
+		</#if>
+	<#else>
+		<#assign theauthor="" />
+  </#if>
+	<#switch content.date?string("d")>
+		<#case "1">
+			<#assign ordsuf="st">
+			<#break>
+		<#case "2">
+		  <#assign ordsuf="nd">
+			<#break>
+		<#case "3">
+			<#assign ordsuf="rd">
+			<#break>
+		<#default>
+			<#assign ordsuf="th">
+	</#switch>
+
+	<p>
+		<em>Published ${theauthor}on the
+			<time datetime="${content.date?date?string.iso}">${content.date?string("dd")}${ordsuf} of ${content.date?string("MMMM, yyyy")}</time>
+		</em>
+	</p>
 
 	${content.body}
 


### PR DESCRIPTION
- Adds `<time>` tag (fixes [SHIRO-856](https://issues.apache.org/jira/browse/SHIRO-856)).
- Proper date formatting.
- Add ordinal suffix to date.
- link author using `rel=author`
- Make sure to write the month name in English.