### PR TITLE
[SHIRO-866] 1.9.0 update and announcement

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -28,6 +28,11 @@ Git will automatically convert line endings for you.
 
 == Changes for a new Apache Shiro Release
 
+=== Changes to link:src/site/content/download.adoc[]
+
+* Update the header attribute `:jbake-releases: {"versions":["shiro19x"]}`.
+* Keep the `x` at the end, as we only promote the latest bugfix release for a given minor version.
+
 === Changes to link:data/releases.yaml[]
 
 * Change `latestRelease: "..."` to the new version.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -33,9 +33,9 @@ Git will automatically convert line endings for you.
 * Change `latestRelease: "..."` to the new version.
 * Update the `versionInfo` object accordingly. +
 You can just add a new release, there is no need to remove old releases.
-* Update the `oldReleases`/`releases` variable like so:
+* Update the `oldReleases`/`releases` variable:
 ** If the new `latestRelease` is a new minor release (e.g. `1.n.0`, where `n` is the new minor release version), prepend the old version to the `oldReleases` array. +
-Also add it to the 'releases' object at the end of the file as `1nx`.
+Also, add it to the 'releases' object at the end of the file as `1nx`.
 ** If the new `latestRelease` is a bugfix release (e.g. `1.n.x`), update the version number of the `releases` object at the end of the file. +
 _Rationale:_ Every minor release should only be represented with the latest bugfix release.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,3 +1,22 @@
+////
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+////
+
 = Apache Shiro Site: Contributing
 
 == General guidelines
@@ -11,13 +30,14 @@ Git will automatically convert line endings for you.
 
 === Changes to link:data/releases.yaml[]
 
-* If the new `latestRelease` is a new minor release (e.g. `1.x.0`), prepend the old version to the `oldReleases` array. +
-Please skip this step for minor releases.
-* If the new `latestRelease` is a minor release, update the version number of the `releases` object at the end of the file. +
-_Rationale:_ Every minor release should only be represented with the latest bugfix release.
 * Change `latestRelease: "..."` to the new version.
 * Update the `versionInfo` object accordingly. +
 You can just add a new release, there is no need to remove old releases.
+* Update the `oldReleases`/`releases` variable like so:
+** If the new `latestRelease` is a new minor release (e.g. `1.n.0`, where `n` is the new minor release version), prepend the old version to the `oldReleases` array. +
+Also add it to the 'releases' object at the end of the file as `1nx`.
+** If the new `latestRelease` is a bugfix release (e.g. `1.n.x`), update the version number of the `releases` object at the end of the file. +
+_Rationale:_ Every minor release should only be represented with the latest bugfix release.
 
 === Changes to link:data/artifacts.yaml[]
 
@@ -25,6 +45,13 @@ In the unlikely event that new artifacts were generated, please modify link:data
 Do not delete artifacts, as they may be in use for old versions.
 
 After modifying the artifacts file, update the `releases` object in link:data/releases.yaml[] to include the new artifact's name.
+
+=== Changes to link:src/site/assets/.htaccess[]
+
+Look for hard coded versions and replace them.
+
+Unfortunately, JBake does not allow custom types.
+For this reason, templating is not availble for `.htaccess` files.
 
 == Development server
 

--- a/data/releases.yaml
+++ b/data/releases.yaml
@@ -1,15 +1,18 @@
 ---
 # for each release, update this variable with the latest version.
-latestRelease: "1.8.0"
+latestRelease: "1.9.0"
 
 # also add or replace the latest version here.
 versionInfo:
+  '1.9.0':
+    releaseDate: 2022-02-18
   '1.8.0':
     releaseDate: 2021-08-06
 
 # oldReleases contain a list of all releases but the most recent one.
 # this is used for release-archive.adoc.
 oldReleases:
+  - shiro18x
   - shiro17x
   - shiro16x
   - shiro15x
@@ -170,3 +173,28 @@ releases:
       - sha1
       # sha512
       # sha3512
+
+  shiro19x:
+    version: 1.9.0
+    artifacts:
+      - shiroAll
+      - shiroCore
+      - shiroWeb
+      - shiroServletPlugin
+      - shiroJaxrs
+      - shiroAspectJ
+      - shiroCas
+      - shiroEhCache
+      - shiroHazelcast
+      - shiroFeatures
+      - shiroGuice
+      - shiroQuartz
+      - shiroSpring
+      - shiroSpringBoot
+      - shiroSpringBootWeb
+      - shiroHasher
+    hashes:
+      - md5
+      - sha1
+      - sha512
+      - sha3512

--- a/data/releases.yaml
+++ b/data/releases.yaml
@@ -5,7 +5,7 @@ latestRelease: "1.9.0"
 # also add or replace the latest version here.
 versionInfo:
   '1.9.0':
-    releaseDate: 2022-02-18
+    releaseDate: 2022-03-22
   '1.8.0':
     releaseDate: 2021-08-06
 

--- a/src/site/assets/.htaccess
+++ b/src/site/assets/.htaccess
@@ -51,5 +51,5 @@ RedirectMatch /static/1.1.0(.*) /static/current$1
 RedirectMatch /static/1.0.0-incubating(.*) /static/current$1
 
 # latest
-RedirectMatch /static/current(.*) /static/1.8.0$1
-RedirectMatch /static/latest(.*) /static/1.8.0$1
+RedirectMatch /static/current(.*) /static/1.9.0$1
+RedirectMatch /static/latest(.*) /static/1.9.0$1

--- a/src/site/content/blog/2022/02/18/apache-shiro-190-released.adoc
+++ b/src/site/content/blog/2022/02/18/apache-shiro-190-released.adoc
@@ -99,6 +99,8 @@ Google Analytics with Matomo for new Javadocs
 
 * [https://issues.apache.org/jira/browse/SHIRO-841[SHIRO-841]] -
 NullPointerException from SessionsSecurityManager.start()
+* [https://issues.apache.org/jira/browse/SHIRO-867[SHIRO-867]] - Skip Deployment of integration-test and samples artifacts
+
 
 === Dependency upgrade
 
@@ -114,10 +116,7 @@ maven-javadoc-plugin to 3.3.1
 
 == Download
 
-Release binaries (.jars) are also available through Maven Central and source bundles through Apache distribution mirrors.
-
-You can link:/download.html[download them directly] from out website as well.
-
+Download and verification instructions are available link:/download.html[on our download page].
 
 == Documentation
 

--- a/src/site/content/blog/2022/02/18/apache-shiro-190-released.adoc
+++ b/src/site/content/blog/2022/02/18/apache-shiro-190-released.adoc
@@ -1,0 +1,128 @@
+////
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+////
+
+= Apache Shiro 1.9.0 Released
+Benjamin Marwell
+:jbake-date: 2022-02-18 16:26:37
+:jbake-type: post
+:jbake-status: published
+:jbake-tags: blog, release
+:idprefix:
+:icons: font
+
+The Shiro team is pleased to announce the release of Apache Shiro version 1.9.0.
+This is a feature release for 1.x.
+
+This release solves 20 issues since the 1.8.0 release and is available for download now.
+
+== Breaking changes
+
+* We fixed [https://issues.apache.org/jira/browse/SHIRO-829[SHIRO-829]] by changing the class signature of the class `ShiroFilterFactoryBean`:
++
+[source,diff]
+----
+-public class ShiroFilterFactoryBean implements FactoryBean, BeanPostProcessor {
++public class ShiroFilterFactoryBean implements FactoryBean<AbstractShiroFilter>, BeanPostProcessor {
+----
++
+and the method signature of `public Class<?> getObjectType`:
++
+[source,diff]
+----
+-    public Class getObjectType() {
+-        return SpringShiroFilter.class;
++    public Class<?> getObjectType() {
++        return AbstractShiroFilter.class;
+----
+
+While we do not expect to break any builds or runtimes, these changes are (strictly speaking) breaking changes as they introduce Generics to this class.
+
+
+== All changes
+
+You can learn more on link:https://issues.apache.org/jira/projects/SHIRO/versions/12350639[Jira, Release 1.9.0].
+
+=== Bug
+
+* [https://issues.apache.org/jira/browse/SHIRO-829[SHIRO-829]] -
+beanPostProcessor and FactoryBean cause aop to fail in the same
+Configuration
+* [https://issues.apache.org/jira/browse/SHIRO-845[SHIRO-845]] -
+Dependencies for test-jars missing
+
+=== Improvement
+
+* [https://issues.apache.org/jira/browse/SHIRO-804[SHIRO-804]] - Avoid
+conflicts with spring boot aop
+* [https://issues.apache.org/jira/browse/SHIRO-836[SHIRO-836]] - Delete
+jsecurty-sample.jks
+* [https://issues.apache.org/jira/browse/SHIRO-838[SHIRO-838]] - Create
+SHA512-Hashes
+* [https://issues.apache.org/jira/browse/SHIRO-846[SHIRO-846]] -
+Creation of site takes very long time
+* [https://issues.apache.org/jira/browse/SHIRO-848[SHIRO-848]] -
+Relative Path in pom.xml is not needed
+* [https://issues.apache.org/jira/browse/SHIRO-850[SHIRO-850]] - The
+profile name jdk19-plus is misleading
+* [https://issues.apache.org/jira/browse/SHIRO-851[SHIRO-851]] -
+Handling properties for compile/enconding vs. default configurations of
+plugins
+* [https://issues.apache.org/jira/browse/SHIRO-852[SHIRO-852]] -
+Configuration for maven-release-plugin prepationGoal should be changed
+* [https://issues.apache.org/jira/browse/SHIRO-853[SHIRO-853]] -
+Versions of maven-surefire/failsafe/report plugin are not in sync
+* [https://issues.apache.org/jira/browse/SHIRO-854[SHIRO-854]] -
+Konfiguration includes/excludes maven-failsafe-plugin can be reduced to
+default
+* [https://issues.apache.org/jira/browse/SHIRO-860[SHIRO-860]] - update
+logback to 1.2.10
+* [https://issues.apache.org/jira/browse/SHIRO-862[SHIRO-862]] - Replace
+Google Analytics with Matomo for new Javadocs
+
+=== Task
+
+* [https://issues.apache.org/jira/browse/SHIRO-841[SHIRO-841]] -
+NullPointerException from SessionsSecurityManager.start()
+
+=== Dependency upgrade
+
+* [https://issues.apache.org/jira/browse/SHIRO-828[SHIRO-828]] -
+aspectj-maven-plugin 1.14.0
+* [https://issues.apache.org/jira/browse/SHIRO-842[SHIRO-842]] -
+shiro-web depends on older log4j
+* [https://issues.apache.org/jira/browse/SHIRO-843[SHIRO-843]] - Update
+maven-project-info-reports
+* [https://issues.apache.org/jira/browse/SHIRO-844[SHIRO-844]] - Update
+maven-javadoc-plugin to 3.3.1
+
+
+== Download
+
+Release binaries (.jars) are also available through Maven Central and source bundles through Apache distribution mirrors.
+
+You can link:/download.html[download them directly] from out website as well.
+
+
+== Documentation
+
+For more information on link:/documentation.html[Shiro, please read the documentation.]
+
+Enjoy!
+
+The Apache Shiro Team

--- a/src/site/content/blog/2022/03/22/apache-shiro-190-released.adoc
+++ b/src/site/content/blog/2022/03/22/apache-shiro-190-released.adoc
@@ -19,7 +19,7 @@
 
 = Apache Shiro 1.9.0 Released
 Benjamin Marwell
-:jbake-date: 2022-02-18 16:26:37
+:jbake-date: 2022-02-22 21:39:37
 :jbake-type: post
 :jbake-status: published
 :jbake-tags: blog, release

--- a/src/site/content/blog/2022/03/22/apache-shiro-190-released.adoc
+++ b/src/site/content/blog/2022/03/22/apache-shiro-190-released.adoc
@@ -19,7 +19,7 @@
 
 = Apache Shiro 1.9.0 Released
 Benjamin Marwell
-:jbake-date: 2022-02-22 21:39:37
+:jbake-date: 2022-03-22 21:39:37
 :jbake-type: post
 :jbake-status: published
 :jbake-tags: blog, release

--- a/src/site/content/download.adoc
+++ b/src/site/content/download.adoc
@@ -2,7 +2,7 @@
 :jbake-type: download
 :jbake-status: published
 :jbake-tags: documentation, download
-:jbake-releases: {"versions":["shiro18x"]}
+:jbake-releases: {"versions":["shiro19x"]}
 :idprefix:
 :icons: font
 


### PR DESCRIPTION
fixes [SHIRO-866](https://issues.apache.org/jira/browse/SHIRO-866).

@fpapon the date is set to this friday (2022-02-18).
We will probably need to change this, alone for the 72h vote cycle.