### PR TITLE
[SHIRO-838] promote source release with SHA-512

### DIFF
--- a/src/site/templates/download.ftl
+++ b/src/site/templates/download.ftl
@@ -23,9 +23,9 @@
     <#assign release=versions.releases[version] />
     <li><a href="#${release.version?replace(".", "")}">Apache Shiro Release v${release.version}</a></li>
     <ul>
-      <li><a href="#${release.version?replace(".", "")}Binary">${release.version} Binary Distribution</a></li>
       <li><a href="#${release.version?replace(".", "")}Source">${release.version} Source Code Distribution</a></li>
       <li><a href="#${release.version?replace(".", "")}Git">${release.version} Git Source repository</a></li>
+      <li><a href="#${release.version?replace(".", "")}Binary">${release.version} Binaries</a></li>
     </ul>
   </#list>
   </ul>
@@ -38,37 +38,36 @@
   <section id="${release.version?replace(".", "")}">
   <h2>Release ${release.version}</h2>
 
-  <h3 id="${release.version?replace(".", "")}Binary">${release.version} Binary Distribution</h3>
-
-
-  <p>Associated documentation can be found <a href="documentation.html" title="Documentation">here</a></p>
-
-  <p>To download the files directly as one .jar file just click the link in the "Artifact" column. If you would like
-    acquire Shiro through Maven, then please use the markup listed under "Maven Usage"</p>
-
-  <p>
-  </p>
-
-  <@artifacttable.artifactTable versionObject=release />
-
   <h3 id="${release.version?replace(".", "")}Source">${release.version} Source Code Distribution</h3>
 
-  <p>The source bundle requires JDK 1.8 and Maven 3.0.3+ to build:</p>
+  <p>The source bundle requires JDK 1.8 and Maven 3.0.3+ to build:
 
-  <p><a class="external-link" href="https://www.apache.org/dyn/closer.lua/shiro/${release.version}/shiro-root-${release.version}-source-release.zip">zip</a>
+  <code><a class="external-link" href="https://www.apache.org/dyn/closer.lua/shiro/${release.version}/shiro-root-${release.version}-source-release.zip">shiro-root-${release.version}-source-release.zip</a></code>
     (<a class="external-link"
         href="https://www.apache.org/dist/shiro/${release.version}/shiro-root-${release.version}-source-release.zip.asc">pgp</a>, <a
             class="external-link"
             href="https://www.apache.org/dist/shiro/${release.version}/shiro-root-${release.version}-source-release.zip.sha512">sha512</a>)
   </p>
 
+  <p>Associated documentation can be found <a href="documentation.html" title="Documentation">here</a></p>
+
   <h3 id="${release.version?replace(".", "")}Git">${release.version} Git Source repository</h3>
 
   <p>The source can be cloned anonymously from Git with this command:</p>
   <pre><code class="language-bash bash">git clone https://github.com/apache/shiro.git
-git switch shiro-root-${release.version}
+git checkout shiro-root-${release.version}
 </code>
 </pre>
+
+  <h3 id="${release.version?replace(".", "")}Binary">${release.version} Binaries</h3>
+
+  <p>If you don't want to build yourself, you can download pre-built binaries from Maven Central, just click the link in the "Artifact" column. If you would like
+    acquire Shiro through Maven, then please use the markup listed under "Maven Usage"</p>
+
+  <p>
+  </p>
+
+  <@artifacttable.artifactTable versionObject=release />
 
   </section>
 

--- a/src/site/templates/macros/artifacttable.ftl
+++ b/src/site/templates/macros/artifacttable.ftl
@@ -23,15 +23,7 @@
 
     <td style="white-space: nowrap;">
       <a href="https://repo1.maven.org/maven2/${group}/${artifact.a}/${version}/${artifact.a}-${version}${classifier!}.${artifact.type}">${artifact.a}</a><br/>
-      (<a href="https://repo1.maven.org/maven2/${group}/${artifact.a}/${version}/${artifact.a}-${version}${classifier!}.${artifact.type}.asc">pgp</a>,
-      <#if versionObject.hashes??>
-        <#list versionObject.hashes>
-          <#items as hash><a href="https://repo1.maven.org/maven2/${group}/${artifact.a}/${version}/${artifact.a}-${version}${classifier!}.${artifact.type}.${hash}">${hash}</a><#sep>, </#sep></#items>)
-        </#list>
-      <#else>
-       <a href="https://repo1.maven.org/maven2/${group}/${artifact.a}/${version}/${artifact.a}-${version}${classifier!}.${artifact.type}.md5">md5</a>,
-       <a href="https://repo1.maven.org/maven2/${group}/${artifact.a}/${version}/${artifact.a}-${version}${classifier!}.${artifact.type}.sha1">sha1</a>)
-      </#if>
+      (<a href="https://repo1.maven.org/maven2/${group}/${artifact.a}/${version}/${artifact.a}-${version}${classifier!}.${artifact.type}.asc">pgp</a>)
     </td>
 
     <td>


### PR DESCRIPTION
different approach to https://github.com/apache/shiro/pull/349

what is important is source release archive with its SHA-512 checksum, published in Apache distribution area https://dlcdn.apache.org/shiro/

convenience binaries published to Maven Central are just convenience pre-built binaries