### PR TITLE
Avoid confusion of users due to 'shiro-jakarta-ee' is not available in Shiro 1.x

### DIFF
--- a/src/site/content/jakarta-ee.adoc
+++ b/src/site/content/jakarta-ee.adoc
@@ -17,7 +17,7 @@ The module is compatible with Java EE 8 through Jakarta EE 10 or later. It may w
 Include the `shiro-jakarta-ee` dependency in you application classpath (we recommend using a tool such as Apache Maven or Gradle to manage this).
 
 ++++
-<@dependencies.dependencies anchorId="cli" deps=[{'g':'org.apache.shiro', 'a':'shiro-jakarta-ee', "v":"${versions.latestRelease}"}] />
+<@dependencies.dependencies anchorId="cli" deps=[{'g':'org.apache.shiro', 'a':'shiro-jakarta-ee', "v":"${versions.latestAlphaRelease}"}] />
 ++++
 
 == Relationships between Jakarta EE and CDI / Jax-RS modules

--- a/src/site/data/releases.yaml
+++ b/src/site/data/releases.yaml
@@ -1,6 +1,9 @@
 ---
 # for each release, update this variable with the latest version.
 latestRelease: "1.11.0"
+# for each alpha release, update this variable with the latest alpha version.
+# it can be dropped after shiro 2 goes final.
+latestAlphaRelease: "2.0.0-alpha-2"
 
 # also add or replace the latest version here.
 versionInfo:

--- a/src/site/templates/macros/versions.ftl
+++ b/src/site/templates/macros/versions.ftl
@@ -1,4 +1,5 @@
 <#assign latestRelease = data.get('releases.yaml').latestRelease>
+<#assign latestAlphaRelease = data.get('releases.yaml').latestAlphaRelease>
 <#assign versionInfo = data.get('releases.yaml').versionInfo>
 <#assign releases = data.get('releases.yaml').releases>
 <#assign oldReleases = data.get('releases.yaml').oldReleases>


### PR DESCRIPTION
# What does this PR do?

It confuses users, that the website states, that the `shiro-jakarta-ee` module is available in Shiro `1.11.0`:

![image](https://github.com/apache/shiro-site/assets/13417392/aa7019a7-c50a-4536-9886-70b59ab72f9f)

This PR introduces `latestAlphaRelease` in `releases.yaml` to provide users with the correct version for `shiro-jakarta-ee`.
We can drop this variable / alpha after Shiro 2 is up and shiny ;-)

![image](https://github.com/apache/shiro-site/assets/13417392/417d4c15-81b0-4adc-bcec-198a22f7710c)


