### PR TITLE
[#185] update documentation on shiro2

### DIFF
--- a/src/site/content/command-line-hasher.adoc
+++ b/src/site/content/command-line-hasher.adoc
@@ -37,12 +37,14 @@ Once you have access to the jar, you can run the following command:
 $ java -jar shiro-tools-hasher-${versions.latestRelease}-cli.jar
 ----
 
-This will print all available options for both standard (MD5, SHA1) and more complex password hashing scenarios.
+This will print all available options for standard (argon2, bcrypt) and less secure hashing scenarios.
 
 [#CommandLineHasher-CommonScenarios]
 == Common Scenarios
 
-Please read the printed instructions for the above command. It will provide an exhaustive list of instructions which will help you use the hasher depending on your needs. However, we've provided some quick reference usages/scenarios below for convenience.
+Please read the printed instructions for the above command.
+It will provide an exhaustive list of instructions which will help you use the hasher depending on your needs.
+However, we've provided some quick reference usages/scenarios below for convenience.
 
 [#CommandLineHasher-shiro.iniUserPasswords]
 === `shiro.ini` User Passwords
@@ -62,11 +64,12 @@ Password to hash:
 Password to hash (confirm):
 ----
 
-When this command executes, it will print out the securely-salted-iterated-and-hashed password. For example:
+When this command executes, it will print out the securely-salted-iterated-and-hashed password.
+For example:
 
 [source,bash]
 ----
-$shiro1$SHA-256$500000$eWpVX2tGX7WCP2J+jMCNqw==$it/NRclMOHrfOvhAEFZ0mxIZRdbcfqIBdwdwdDXW2dM=
+[INFO ] $shiro2$argon2id$v=19$t=1,m=65536,p=4$H5z81Jpr4ntZr3MVtbOUBw$fJDgZCLZjMC6A2HhnSpxULMmvVdW3su+/GCU3YbxfFQ
 ----
 
 Take this value and place it as the password in the user definition line (followed by any optional roles) as defined in the link:/configuration.html#Configuration-INIConfiguration-Sections-users[INI Users Configuration] documentation. For example:
@@ -75,10 +78,11 @@ Take this value and place it as the password in the user definition line (follow
 ----
 [users]
 ...
-user1 = $shiro1$SHA-256$500000$eWpVX2tGX7WCP2J+jMCNqw==$it/NRclMOHrfOvhAEFZ0mxIZRdbcfqIBdwdwdDXW2dM=
+user1 = $shiro2$argon2id$v=19$t=1,m=65536,p=4$H5z81Jpr4ntZr3MVtbOUBw$fJDgZCLZjMC6A2HhnSpxULMmvVdW3su+/GCU3YbxfFQ
 ----
 
-You will also need to ensure that the implicit `iniRealm` uses a `CredentialsMatcher` that knows how to perform secure hashed password comparisons. So configure this in the `[main]` section as well:
+You will also need to ensure that the implicit `iniRealm` uses a `CredentialsMatcher` that knows how to perform secure hashed password comparisons.
+So configure this in the `[main]` section as well:
 
 [source,ini]
 ----

--- a/src/site/content/configuration.adoc
+++ b/src/site/content/configuration.adoc
@@ -439,40 +439,33 @@ Each line in the [users] section must conform to the following format:
 [#Configuration-INIConfiguration-Sections-users-EncryptingPasswords]
 ===== Encrypting Passwords
 
-If you don't want the [users] section passwords to be in plain-text, you can encrypt them using your favorite hash algorithm (MD5, Sha1, Sha256, etc.) however you like and use the resulting string as the password value. By default, the password string is expected to be Hex encoded, but can be configured to be Base64 encoded instead (see below).
+Since Shiro 2.0, the `[users]` section cannot contain plain-text passwords.
+You can encrypt them using https://en.wikipedia.org/wiki/Key_derivation_function[key derivation functions].
+Shiro provides implementations for bcrypt and argon2.
+If unsure, use argon2 derived passwords.
+
+The algorithms from Shiro 1 (e.g. md5, SHA1, SHA256, etc.) are long deemed insecure and not supported anymore.
+There is neither a direct migration path nor backward compatibility.
+
 
 [NOTE]
 ====
 .Easy Secure Passwords
-To save time and use best-practices, you might want to use Shiro's link:command-line-hasher.html[Command Line Hasher], which will hash passwords as well as any other type of resource. It is especially convenient for encrypting INI `[users]` passwords.
+To save time and use best-practices, you might want to use Shiro's link:command-line-hasher.html[Command Line Hasher], which will apply one of the secure KDFs to a given password as well as any other type of resources.
+It is especially convenient for encrypting INI `[users]` passwords.
 ====
 
-Once you've specified the hashed text password values, you have to tell Shiro that these are encrypted. You do that by configuring the implicitly created `iniRealm` in the [main] section to use an appropriate `CredentialsMatcher` implementation corresponding to the hash algorithm you've specified:
+Once you've specified the derived text password values, you have to tell Shiro that these are encrypted.
+You do that by configuring the implicitly created `iniRealm` in the [main] section to use an appropriate `CredentialsMatcher` implementation corresponding to the hash algorithm you've specified:
 
 [source,ini]
 ----
 [main]
-...
-sha256Matcher = org.apache.shiro.authc.credential.Sha256CredentialsMatcher
-...
-iniRealm.credentialsMatcher = $sha256Matcher
-...
+# Shiro2CryptFormat
 
 [users]
 # user1 = sha256-hashed-hex-encoded password, role1, role2, ...
-user1 = 2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b, role1, role2, ...
-----
-
-You can configure any properties on the `CredentialsMatcher` like any other object to reflect your hashing strategy, for example, to specify if salting is used or how many hash iterations to execute. See the link:static/current/apidocs/org/apache/shiro/authc/credential/HashedCredentialsMatcher.html[`org.apache.shiro.authc.credential.HashedCredentialsMatcher`] JavaDoc to better understand hashing strategies and if they might be useful to you.
-
-For example, if your users' password strings were Base64 encoded instead of the default Hex, you could specify:
-
-[source,ini]
-----
-[main]
-...
-# true = hex, false = base64:
-sha256Matcher.storedCredentialsHexEncoded = false
+user1 = $shiro2$argon2id$v=19$t=1,m=65536,p=4$H5z81Jpr4ntZr3MVtbOUBw$fJDgZCLZjMC6A2HhnSpxULMmvVdW3su+/GCU3YbxfFQ, role1, role2, ...
 ----
 
 [#Configuration-INIConfiguration-Sections-roles]

--- a/src/site/content/cryptography-features.adoc
+++ b/src/site/content/cryptography-features.adoc
@@ -51,9 +51,13 @@ Shiro will automatically enable the more secure options to ensure your data is a
 [#CryptographyFeatures-HashFeatures]
 == Hash Features
 
+* *Default KDF algorithms* *
+Shiro 2 provides argon2 and bcrypt support out of the box.
+Passwords should not be saved using hash algorithms, but modern KDFs do provide a sensible level of security against brute force attacks.
+
 * *Default interface implementations* +
-Shiro provides default Hash (aka Message Digests in the JDK) implementations out-of-the-box, such as MD5, SHA1, SHA-256, et al.
-This provides a type-safe construction method (e.g. `new Md5Hash(data)`) instead of being forced to use type-unsafe string factory methods in the JDK.
+Shiro provides default Hash (aka Message Digests in the JDK) implementations out-of-the-box, such as SHA-256, SHA-386, SHA-512, et al.
+This provides a type-safe construction method (e.g. `new Sha256Hash(data)`) instead of being forced to use type-unsafe string factory methods in the JDK.
 
 * *Built-in Hex and Base64 conversion* +
 Shiro Hash instances can automatically provide Hex and Base-64 encoding of hashed data via their `toHex()` and `toBase64()` methods.


### PR DESCRIPTION
Looking at this, does the ini parser even work now? We need to investigate before we can release Shiro 2.

Especially:

```
user1 = $shiro2$argon2id$v=19$t=1,m=65536,p=4$H5z81Jpr4ntZr3MVtbOUBw$fJDgZCLZjMC6A2HhnSpxULMmvVdW3su+/GCU3YbxfFQ, role1, role2, ...
```

I cannot recall if we tested this properly (commas...).