### PR TITLE
`README.adoc`: remove small black dot above "F" in "ASF"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ Site content is authored as Markdown, Asciidoc and HTML files.
 These files are parsed by the tool `jbake` and renders the content files using freemarker templates to static `.html` files.
 
 To publish the site commit changes to the `asf-site` branch of this repository.
-ASF infrastructure will see the commit and automatically push the changes to the ASF͘'s production webservers.
+ASF infrastructure will see the commit and automatically push the changes to the ASF's production webservers.
 
 == Generating and Publishing
 


### PR DESCRIPTION
<img width="975" height="299" alt="Screenshot from 2025-10-21 03-06-53" src="https://github.com/user-attachments/assets/5339eca8-0b10-44b2-ab62-ae693dc990ac" />
