### PR TITLE
Optimize Dependabot by using `groups` for `github-actions` ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,7 @@ updates:
     schedule:
       interval: 'daily'
     open-pull-requests-limit: 10
+    groups:
+      github-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
refs https://github.com/apache/shiro/pull/2340