### PR TITLE
Add documentation for CORS pre-flight requests support

### DIFF
--- a/src/site/content/web.adoc
+++ b/src/site/content/web.adoc
@@ -468,6 +468,25 @@ If you're currently allowing URL rewriting to allow for a <code>jsessionid</code
 URL rewriting for `jsessionid` is defined in section "7.1.3" of the Java Servlet Specification, but it is generally NOT recommended.
 ====
 
+=== CORS Support
+
+When using HTTP-based authentication (like Basic Auth or Bearer Token) in a browser-based application, Cross-Origin Resource Sharing (CORS) pre-flight `OPTIONS` requests are often sent by the browser. By default, these requests might be rejected if they do not contain authentication headers.
+
+To allow pre-flight `OPTIONS` requests to pass through the authentication filter without requiring credentials, you can configure the `allowPreFlightRequests` property on any filter extending `HttpAuthenticationFilter`.
+
+This is commonly used with `authcBasic` (Basic Auth) or `authcBearer` (Bearer Token / JWT).
+
+[source,ini]
+----
+[main]
+...
+# Example 1: Configuring Basic Auth for CORS
+authcBasic.allowPreFlightRequests = true
+
+# Example 2: Configuring Bearer Auth (if used) for CORS
+authcBearer.allowPreFlightRequests = true
+...
+----
 
 === HTTP Strict Transport Security (HSTS)
 


### PR DESCRIPTION
This PR adds documentation for the `allowPreFlightRequests` property on `HttpAuthenticationFilter`. This configuration allows CORS pre-flight `OPTIONS` requests to pass through authentication filters (like `authcBasic` or `authcBearer`) without requiring credentials.

Refs: https://github.com/apache/shiro/pull/2372

Fixes: #255 