### PR TITLE
[CI] Dependabot: add a cooldown period for new releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,8 @@ updates:
     open-pull-requests-limit: 50
     registries:
       - maven-central
+    cooldown:
+      default-days: 7
 
   # Dependencies for GitHub Actions
   - package-ecosystem: 'github-actions'
@@ -43,3 +45,5 @@ updates:
       github-dependencies:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Enforces security best practices by requiring a minimum age for new dependency releases before they are automatically updated by Dependabot.

This practice, known as a "cooldown period," helps mitigate supply chain attacks by allowing time for frequently published malicious packages to be identified.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-


refs https://github.com/apache/cloudstack/pull/12384