### PR TITLE
security-model.adoc: draft additions for adversary model, known non-findings, triage dispositions

### DIFF
--- a/src/site/content/security-model.adoc
+++ b/src/site/content/security-model.adoc
@@ -39,6 +39,37 @@ However, Shiro relies on the application to:
 * Protect sensitive configuration values from exposure.
 * Implement proper transport-layer security (TLS/SSL) for credential transmission.
 
+== Adversary Model
+
+Shiro's security model assumes the following adversary classes:
+
+=== External Untrusted Adversary (in scope)
+
+*(inferred)* The primary adversary Shiro defends against is an unauthenticated or authenticated-but-low-privilege network user attempting to access an application that integrates Shiro. This adversary can:
+
+* Submit arbitrary authentication credentials, session identifiers, and request data.
+* Observe authentication error responses (including timing).
+* Attempt session fixation, privilege escalation, and authorization bypass.
+
+This adversary cannot:
+
+* Run code in the application's JVM process.
+* Read or modify application configuration files.
+* Tamper with `Realm` implementations or their backing data sources.
+
+=== Authenticated User with Limited Privileges (in scope)
+
+*(inferred)* Shiro's authorization model defends against privilege escalation by an authenticated user. A user authenticated under one principal must not gain access to resources they are not authorized for through permission-string manipulation or session-state tampering.
+
+=== Adversaries Out of Scope
+
+The following adversary classes are explicitly *not* part of Shiro's threat model — defending against them is the application's or operator's responsibility:
+
+* **Application Code**: *(documented)* As stated in <<Application-Level Trust>>, Shiro trusts the code that invokes its APIs. An attacker who can execute arbitrary code in the application's JVM has already won at Shiro's layer.
+* **Administrators with Configuration Access**: *(documented)* An attacker controlling INI files, Spring beans, or other configuration sources can disable security controls. Shiro relies on operators to secure these.
+* **Local Shell Access / Co-Tenants**: *(inferred)* An attacker with shell access to the host can read process memory, log files, and the keystore. Shiro does not defend against this; isolate Shiro-secured applications appropriately.
+* **Compromised Realms**: *(documented)* An attacker controlling the LDAP server, database, or other `Realm` backing data can grant arbitrary access. Realm data sources are part of the trust boundary.
+
 == Authentication Guarantees
 
 === What Shiro Provides
@@ -163,6 +194,75 @@ Shiro should be one layer in a defense-in-depth security strategy:
 * Employ rate limiting and brute-force protection at the infrastructure level.
 * Conduct regular security assessments and penetration testing.
 
+== Known Non-Findings
+
+The following recurring report categories are explicitly *not* security vulnerabilities under Shiro's model. Reporters should consult this list before filing — a report matching one of these will be closed with a reference back to this section.
+
+=== Username Enumeration via Differential Error Responses
+
+*(documented)* By default, Shiro returns different exceptions for "unknown account" vs "incorrect password" (see <<Username Enumeration>>). This is the framework's default behavior; applications that need to prevent enumeration must configure their `Realm` to return consistent exceptions, as documented above.
+
+=== Username and Session ID Appearing in Logs
+
+*(documented)* As stated in <<Logging>>, principals (usernames) may appear in Shiro's SLF4J logs, and session identifiers may appear at DEBUG level. This is by design — log content is the operator's responsibility to secure. Plaintext passwords are not logged; that's the property Shiro maintains.
+
+=== Shiro Version Disclosure
+
+*(documented)* Per <<Version Discovery>>, Shiro does not actively prevent version disclosure through error messages or response headers. Operators who treat version disclosure as a finding must configure their web server, proxy, or custom error pages accordingly.
+
+=== Deprecated Hash Algorithms Exposed in the Hashing API
+
+*(inferred)* Shiro's `Hash` and `HashService` APIs expose MD5, SHA-1, and other algorithms that are no longer considered safe for new password hashing. These remain available for legacy interoperability and for non-security uses (e.g., content checksums). Reports that "Shiro supports MD5" are not findings; the framework's default for password hashing is the secure `PasswordService`. Operators must select appropriate algorithms.
+
+=== RememberMe with Weaker Authentication Guarantees
+
+*(documented)* Per <<What Shiro Provides>> under <<Authentication Guarantees>>, the RememberMe mechanism explicitly provides weaker guarantees than full authentication. Reports that RememberMe-identified subjects bypass full authentication are not findings; the security tradeoff is documented and intentional.
+
+=== Pluggable Cryptography Allowing Weak Configurations
+
+*(inferred)* Shiro's `CipherService`, `Hash`, and related APIs are pluggable and accept any algorithm registered with the JCA. Configuring Shiro to use a weak cipher is an operator misconfiguration, not a framework vulnerability. Shiro's role is to provide secure defaults and clear documentation, which it does.
+
+=== CSRF, MFA, Account Lockout
+
+*(documented)* Per <<Web Security>>, <<Operator Responsibilities>> under <<Authentication Guarantees>>, and elsewhere, CSRF protection, MFA, and account lockout are explicitly *not* built into Shiro. Operators must implement these at the application or infrastructure level. Reports that "Shiro is missing CSRF protection" are not framework vulnerabilities.
+
+== Triage Dispositions
+
+The Shiro PMC classifies inbound vulnerability reports into one of the following dispositions. Each links to the section of this document that licenses the call.
+
+[cols="1,3,2",options="header"]
+|===
+| Disposition | Meaning | Licensed by
+
+| VALID
+| The report describes a real violation of a property Shiro provides (authentication / authorization / session-handling / crypto / web-security guarantees), accessible to an in-scope adversary through an in-scope code path. Fixed via coordinated disclosure and CVE.
+| <<Authentication Guarantees>>, <<Authorization Guarantees>>, <<Session Management>>, <<Cryptography>>, <<Web Security>>, <<Adversary Model>>
+
+| VALID-HARDENING
+| No property in this model is violated, but the PMC elects to add defensive hardening (e.g., narrowing an API that's easy to misuse). Triaged privately; fixed at PMC discretion; typically no CVE.
+| PMC discretion
+
+| OUT-OF-MODEL: trusted-input
+| The report requires the attacker to control a value or input Shiro treats as trusted (application code, configuration files, realm data).
+| <<Trust Boundaries>>
+
+| OUT-OF-MODEL: adversary-not-in-scope
+| The report requires attacker capabilities Shiro does not defend against (local shell access, JVM control, administrator privileges).
+| <<Adversaries Out of Scope>>
+
+| BY-DESIGN: property-disclaimed
+| The report concerns a property Shiro explicitly does not provide (CSRF, MFA, account lockout, key management, version concealment, etc.).
+| <<Web Security>>, <<Operator Responsibilities>>, <<Cryptography>>, <<Version Discovery>>
+
+| KNOWN-NON-FINDING
+| The report matches one of the documented categories in <<Known Non-Findings>>.
+| <<Known Non-Findings>>
+
+| MODEL-GAP
+| The report cannot be cleanly routed to any of the above. This indicates a gap in the security model itself; the PMC revises the model rather than ad-hoc-deciding the report.
+| triggers a model revision
+|===
+
 == Reporting Security Vulnerabilities
 
 If you discover a security vulnerability in Apache Shiro, please report it privately to the security team:
@@ -171,6 +271,27 @@ If you discover a security vulnerability in Apache Shiro, please report it priva
 * **Process**: See link:security-reports.html[Security Reports] for the full vulnerability handling process.
 
 Do not disclose security vulnerabilities publicly until a fix is available and an advisory has been published.
+
+== Open Questions for the PMC
+
+[NOTE]
+====
+This section is temporary — it collects the `*(inferred)*` tags elsewhere in this document for PMC review. Once the PMC has confirmed, corrected, or struck each item, this section can be removed and the corresponding tags promoted to `*(maintainer)*`.
+====
+
+. *(inferred)* in <<External Untrusted Adversary (in scope)>>: is "attempt session fixation, privilege escalation, and authorization bypass" the right framing for the adversary's intent?
+
+. *(inferred)* in <<Authenticated User with Limited Privileges (in scope)>>: is privilege-escalation-via-permission-string-manipulation in scope as a Shiro-layer concern, or is permission-string construction the application's responsibility?
+
+. *(inferred)* in <<Adversaries Out of Scope>> / Local Shell Access: the framing assumes JVM process is the trust boundary. Confirm or refine.
+
+. *(inferred)* in <<Known Non-Findings>>: "Deprecated Hash Algorithms Exposed in the Hashing API" — is this the right framing, or does the PMC consider it the operator's choice to NOT call the deprecated APIs?
+
+. *(inferred)* in <<Known Non-Findings>>: "Pluggable Cryptography Allowing Weak Configurations" — same question. Is misconfigured cipher selection a Shiro concern or fully the operator's?
+
+. *(inferred)* in <<Triage Dispositions>>: are the seven disposition labels above the right set? The ASF Security team's threat-model-producer rubric uses these labels; the PMC may prefer different terminology.
+
+Reply on the original email thread you started with the Security team, or against this PR with confirmations / corrections.
 
 == Additional Resources
 

--- a/src/site/content/security-model.adoc
+++ b/src/site/content/security-model.adoc
@@ -39,37 +39,6 @@ However, Shiro relies on the application to:
 * Protect sensitive configuration values from exposure.
 * Implement proper transport-layer security (TLS/SSL) for credential transmission.
 
-== Adversary Model
-
-Shiro's security model assumes the following adversary classes:
-
-=== External Untrusted Adversary (in scope)
-
-*(inferred)* The primary adversary Shiro defends against is an unauthenticated or authenticated-but-low-privilege network user attempting to access an application that integrates Shiro. This adversary can:
-
-* Submit arbitrary authentication credentials, session identifiers, and request data.
-* Observe authentication error responses (including timing).
-* Attempt session fixation, privilege escalation, and authorization bypass.
-
-This adversary cannot:
-
-* Run code in the application's JVM process.
-* Read or modify application configuration files.
-* Tamper with `Realm` implementations or their backing data sources.
-
-=== Authenticated User with Limited Privileges (in scope)
-
-*(inferred)* Shiro's authorization model defends against privilege escalation by an authenticated user. A user authenticated under one principal must not gain access to resources they are not authorized for through permission-string manipulation or session-state tampering.
-
-=== Adversaries Out of Scope
-
-The following adversary classes are explicitly *not* part of Shiro's threat model — defending against them is the application's or operator's responsibility:
-
-* **Application Code**: *(documented)* As stated in <<Application-Level Trust>>, Shiro trusts the code that invokes its APIs. An attacker who can execute arbitrary code in the application's JVM has already won at Shiro's layer.
-* **Administrators with Configuration Access**: *(documented)* An attacker controlling INI files, Spring beans, or other configuration sources can disable security controls. Shiro relies on operators to secure these.
-* **Local Shell Access / Co-Tenants**: *(inferred)* An attacker with shell access to the host can read process memory, log files, and the keystore. Shiro does not defend against this; isolate Shiro-secured applications appropriately.
-* **Compromised Realms**: *(documented)* An attacker controlling the LDAP server, database, or other `Realm` backing data can grant arbitrary access. Realm data sources are part of the trust boundary.
-
 == Authentication Guarantees
 
 === What Shiro Provides
@@ -130,12 +99,12 @@ By default, Shiro may reveal whether a username exists through different error r
 
 * **Hashing**: Simplified APIs for cryptographic hashing (SHA-256, SHA-512, MD5, etc.) with salt and iteration support.
 * **Encryption/Decryption**: `CipherService` implementations for symmetric encryption (AES, Blowfish, etc.).
-* **Password Hashing**: `PasswordService` for secure credential hashing with configurable algorithms.
+* **Password Hashing**: `PasswordService` for secure credential hashing with configurable algorithms (Argon2, BCrypt).
 
 === Important Notes
 
 * Shiro's cryptographic utilities are wrappers around standard Java cryptography (JCA/JCE) and `BouncyCastle` libraries.
-* **Algorithm Selection**: Operators must choose appropriate algorithms. Avoid deprecated algorithms (MD5, SHA-1 for security purposes).
+* **Algorithm Selection**: Operators must choose appropriate algorithms. Avoid deprecated algorithms (MD5, SHA-1 for security purposes). Avoid weak algorithms for passwords (use Argon2 or BCrypt with appropriate work factors).
 * **Key Management**: Shiro does not provide key management infrastructure. Secure key storage and rotation is the operator's responsibility.
 
 == Web Security
@@ -182,7 +151,7 @@ Operators should:
 . Use the latest stable Shiro release.
 . Configure TLS for all credential transmission.
 . Use strong password hashing (bcrypt or Argon2 with appropriate work factors).
-. Implement session fixation prevention.
+. Implement session fixation prevention, if not using built-in session management.
 . Review and restrict default configurations.
 
 === Defense in Depth
@@ -194,37 +163,68 @@ Shiro should be one layer in a defense-in-depth security strategy:
 * Employ rate limiting and brute-force protection at the infrastructure level.
 * Conduct regular security assessments and penetration testing.
 
+== Adversary Model
+
+Shiro's security model assumes the following adversary classes:
+
+=== External Untrusted Adversary (in scope)
+
+The primary adversary Shiro defends against is an unauthenticated or authenticated-but-low-privilege network user attempting to access an application that integrates Shiro. This adversary can:
+
+* Submit arbitrary authentication credentials, session identifiers, and request data.
+* Observe authentication error responses (including timing).
+* Attempt session fixation, privilege escalation, and authorization bypass.
+
+This adversary cannot:
+
+* Run code in the application's JVM process.
+* Read or modify application configuration files.
+* Tamper with `Realm` implementations or their backing data sources.
+
+=== Authenticated User with Limited Privileges (in scope)
+
+Shiro's authorization model defends against privilege escalation by an authenticated user. A user authenticated under one principal must not gain access to resources they are not authorized for. Applications must not allow manipulation of permission strings or other inputs that could lead to unauthorized access. Shiro's role and permission checks are only as secure as the application's permission model and input handling.
+
+=== Adversaries Out of Scope
+
+The following adversary classes are explicitly *not* part of Shiro's threat model — defending against them is the application's or operator's responsibility:
+
+* **Application Code**: As stated in <<Application-Level Trust>>, Shiro trusts the code that invokes its APIs. An attacker who can execute arbitrary code in the application's JVM has already won at Shiro's layer.
+* **Administrators with Configuration Access**: An attacker controlling INI files, Spring beans, or other configuration sources can disable security controls. Shiro relies on operators to secure these.
+* **Local Shell Access / Co-Tenants**: An attacker with shell access to the host can read process memory, log files, and the keystore. Shiro does not defend against this; isolate Shiro-secured applications appropriately.
+* **Compromised Realms**: An attacker controlling the LDAP server, database, or other `Realm` backing data can grant arbitrary access. Realm data sources are part of the trust boundary.
+
 == Known Non-Findings
 
 The following recurring report categories are explicitly *not* security vulnerabilities under Shiro's model. Reporters should consult this list before filing — a report matching one of these will be closed with a reference back to this section.
 
 === Username Enumeration via Differential Error Responses
 
-*(documented)* By default, Shiro returns different exceptions for "unknown account" vs "incorrect password" (see <<Username Enumeration>>). This is the framework's default behavior; applications that need to prevent enumeration must configure their `Realm` to return consistent exceptions, as documented above.
+By default, Shiro returns different exceptions for "unknown account" vs "incorrect password" (see <<Username Enumeration>>). This is the framework's default behavior; applications that need to prevent enumeration must configure their `Realm` to return consistent exceptions, as documented above.
 
 === Username and Session ID Appearing in Logs
 
-*(documented)* As stated in <<Logging>>, principals (usernames) may appear in Shiro's SLF4J logs, and session identifiers may appear at DEBUG level. This is by design — log content is the operator's responsibility to secure. Plaintext passwords are not logged; that's the property Shiro maintains.
+As stated in <<Logging>>, principals (usernames) may appear in Shiro's SLF4J logs, and session identifiers may appear at DEBUG level. This is by design — log content is the operator's responsibility to secure. Plaintext passwords are not logged; that's the property Shiro maintains.
 
 === Shiro Version Disclosure
 
-*(documented)* Per <<Version Discovery>>, Shiro does not actively prevent version disclosure through error messages or response headers. Operators who treat version disclosure as a finding must configure their web server, proxy, or custom error pages accordingly.
+Per <<Version Discovery>>, Shiro does not actively prevent version disclosure through error messages or response headers. Operators who treat version disclosure as a finding must configure their web server, proxy, or custom error pages accordingly.
 
 === Deprecated Hash Algorithms Exposed in the Hashing API
 
-*(inferred)* Shiro's `Hash` and `HashService` APIs expose MD5, SHA-1, and other algorithms that are no longer considered safe for new password hashing. These remain available for legacy interoperability and for non-security uses (e.g., content checksums). Reports that "Shiro supports MD5" are not findings; the framework's default for password hashing is the secure `PasswordService`. Operators must select appropriate algorithms.
+Shiro's `Hash` and `HashService` APIs expose MD5, SHA-1, and other algorithms that are no longer considered safe for new password hashing. These remain available for legacy interoperability and for non-security uses (e.g., content checksums). Reports that "Shiro supports MD5" are not findings; the framework's default for password hashing is the secure `PasswordService`. Operators must select appropriate algorithms.
 
 === RememberMe with Weaker Authentication Guarantees
 
-*(documented)* Per <<What Shiro Provides>> under <<Authentication Guarantees>>, the RememberMe mechanism explicitly provides weaker guarantees than full authentication. Reports that RememberMe-identified subjects bypass full authentication are not findings; the security tradeoff is documented and intentional.
+Per <<What Shiro Provides>> under <<Authentication Guarantees>>, the RememberMe mechanism explicitly provides weaker guarantees than full authentication. Reports that RememberMe-identified subjects bypass full authentication are not findings; the security tradeoff is documented and intentional.
 
 === Pluggable Cryptography Allowing Weak Configurations
 
-*(inferred)* Shiro's `CipherService`, `Hash`, and related APIs are pluggable and accept any algorithm registered with the JCA. Configuring Shiro to use a weak cipher is an operator misconfiguration, not a framework vulnerability. Shiro's role is to provide secure defaults and clear documentation, which it does.
+Shiro's `CipherService`, `Hash`, and related APIs are pluggable and accept any algorithm registered with the JCA. Configuring Shiro to use a weak cipher is an operator misconfiguration, not a framework vulnerability. Shiro's role is to provide secure defaults and clear documentation, which it does.
 
 === CSRF, MFA, Account Lockout
 
-*(documented)* Per <<Web Security>>, <<Operator Responsibilities>> under <<Authentication Guarantees>>, and elsewhere, CSRF protection, MFA, and account lockout are explicitly *not* built into Shiro. Operators must implement these at the application or infrastructure level. Reports that "Shiro is missing CSRF protection" are not framework vulnerabilities.
+Per <<Web Security>>, <<Operator Responsibilities>> under <<Authentication Guarantees>>, and elsewhere, CSRF protection, MFA, and account lockout are explicitly *not* built into Shiro. Operators must implement these at the application or infrastructure level. Reports that "Shiro is missing CSRF protection" are not framework vulnerabilities.
 
 == Triage Dispositions
 
@@ -271,27 +271,6 @@ If you discover a security vulnerability in Apache Shiro, please report it priva
 * **Process**: See link:security-reports.html[Security Reports] for the full vulnerability handling process.
 
 Do not disclose security vulnerabilities publicly until a fix is available and an advisory has been published.
-
-== Open Questions for the PMC
-
-[NOTE]
-====
-This section is temporary — it collects the `*(inferred)*` tags elsewhere in this document for PMC review. Once the PMC has confirmed, corrected, or struck each item, this section can be removed and the corresponding tags promoted to `*(maintainer)*`.
-====
-
-. *(inferred)* in <<External Untrusted Adversary (in scope)>>: is "attempt session fixation, privilege escalation, and authorization bypass" the right framing for the adversary's intent?
-
-. *(inferred)* in <<Authenticated User with Limited Privileges (in scope)>>: is privilege-escalation-via-permission-string-manipulation in scope as a Shiro-layer concern, or is permission-string construction the application's responsibility?
-
-. *(inferred)* in <<Adversaries Out of Scope>> / Local Shell Access: the framing assumes JVM process is the trust boundary. Confirm or refine.
-
-. *(inferred)* in <<Known Non-Findings>>: "Deprecated Hash Algorithms Exposed in the Hashing API" — is this the right framing, or does the PMC consider it the operator's choice to NOT call the deprecated APIs?
-
-. *(inferred)* in <<Known Non-Findings>>: "Pluggable Cryptography Allowing Weak Configurations" — same question. Is misconfigured cipher selection a Shiro concern or fully the operator's?
-
-. *(inferred)* in <<Triage Dispositions>>: are the seven disposition labels above the right set? The ASF Security team's threat-model-producer rubric uses these labels; the PMC may prefer different terminology.
-
-Reply on the original email thread you started with the Security team, or against this PR with confirmations / corrections.
 
 == Additional Resources
 


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or
discuss as needed.** The additions below are a *draft*; every claim
carries a provenance tag (`*(documented)*`, `*(maintainer)*`, or
`*(inferred)*`) and all `*(inferred)*` items are collected in a new
"Open Questions for the PMC" section at the bottom so they can be
explicitly confirmed, corrected, or rejected before this is
considered ready.

## Context

The ASF Security team is piloting an automated agentic security
scan with PMCs who have opted in. Apache Shiro is one of the
opted-in PMCs (thread on `private@shiro.apache.org`, Lenny Primak
confirming).

Pre-flight review of the existing security model document showed
substantive coverage of authentication, authorization, session
management, cryptography, web security, and operator
responsibilities. The four sections this PR adds are the
ones the scan rubric expects but that the existing document
either does not address explicitly or addresses only implicitly:

1. **`== Adversary Model`** — names the in-scope adversary
   classes (external untrusted network user; authenticated
   low-privilege user) and explicitly lists what's *out of
   scope* (the application code itself, administrators with
   configuration access, local-shell / co-tenant adversaries,
   compromised realms). This section cross-references the
   existing `Trust Boundaries` section rather than restating it.

2. **`== Known Non-Findings`** — recurring report categories
   that the PMC has already decided are not vulnerabilities
   under the model. Seven categories were lifted from the
   existing document (default username-enumeration behavior,
   username / session-ID appearance in logs, version
   disclosure, deprecated-hash exposure in the API,
   RememberMe's weaker guarantees, pluggable-crypto allowing
   weak operator configurations, omissions of CSRF / MFA /
   account-lockout). Each is linked back to the section that
   licenses the classification.

3. **`== Triage Dispositions`** — a closed set of outcomes
   triagers can pick when handling an inbound report:
   `VALID`, `VALID-HARDENING`, `OUT-OF-MODEL:*`,
   `BY-DESIGN:property-disclaimed`, `KNOWN-NON-FINDING`,
   `MODEL-GAP`. Every cell in the table cross-references
   the section of the model that licenses the call, so the
   reply to a reporter can say "see `<<known_non_findings>>`"
   rather than ad-hoc prose.

4. **`== Open Questions for the PMC`** — temporary section
   collecting every `*(inferred)*` tag elsewhere in the
   document. When the PMC confirms or corrects each item,
   the corresponding tag is promoted to `*(maintainer)*`
   and this section is removed.

## Why these additions and not others

The rubric the team uses is published at
<https://gist.github.com/potiuk/da14a826283038ddfe38cc9fe6310573>.
That gist enumerates roughly a dozen subsections a thorough
threat model is expected to cover. For Shiro, the
existing document already covered most of them substantively
— what was missing (or only implicit) were the four sections
above. Other rubric subsections that *are* already adequately
covered (`§4.2 Architecture` via the existing `Overview` and
`Trust Boundaries`; `§4.3 Trust Boundaries` itself;
`§4.6 Authentication`, `§4.7 Authorization`,
`§4.10 Cryptography`, `§4.12 Operational guidance`, etc.)
are not changed by this PR.

## What this PR does *not* claim

- **It does not claim to be authoritative.** The PMC is.
  Every `*(inferred)*` tag is a hypothesis we'd like the
  PMC to confirm or correct.
- **It does not change any normative behavior.** This is a
  documentation-only PR against `src/site/content/security-model.adoc`.
- **It does not address discoverability.** A separate PR
  against `apache/shiro` adds the discoverability pointers
  (`AGENTS.md` + `SECURITY.md`) the scan rubric also expects.

## How to review

1. **Read the `Open Questions for the PMC` section first.**
   Anything you can answer there moves an `*(inferred)*` tag
   to `*(maintainer)*` in the body and removes one bullet
   from Open Questions.
2. **Reject anything that's wrong.** If a "Known Non-Finding"
   shouldn't be in that category, say so — the framing here
   is *the PMC's* call, not ours.
3. **Add anything missing.** Categories of report Shiro
   has seen repeatedly that aren't in the Known Non-Findings
   table belong there too — we surveyed the existing
   document but didn't survey the historical security-report
   archive.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7), used by the ASF Security
      team to draft the proposed additions against the
      rubric linked above. All content was reviewed by a
      human before submission.

Generated-by: Claude Code (Opus 4.7)
