### PR TITLE
Fix broken link in the integration documentation

### DIFF
--- a/src/site/content/integration.adoc
+++ b/src/site/content/integration.adoc
@@ -159,6 +159,6 @@ Casdoor is a UI-first centralized authentication / Single-Sign-On (SSO) platform
 == Got An Integration?
 
 Have an integration you want listed?
-Send us a pull request of https://github.com/apache/shiro-site/blob/main/integration.md[this page], and participate in Shiro development!
+Send us a pull request of https://github.com/apache/shiro-site/blob/main/src/site/content/integration.adoc[this page], and participate in Shiro development!
 
 link:how-to-contribute.html[Learn more about contributing to Apache Shiro].


### PR DESCRIPTION
# This pull request fixes a broken link in the integration documentation.
- Replaced the outdated [integration.md ](https://github.com/apache/shiro-site/blob/main/integration.md) link.
 - Updated the reference to [src/site/content/integration.adoc](https://github.com/apache/shiro-site/blob/main/src/site/content/integration.adoc)
fixes: #314